### PR TITLE
Update Documentation

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -24,4 +24,4 @@ jobs:
 
       - name: Run unit tests
         run: |
-          python -m unittest discover -v
+          python -m unittest discover -v --durations

--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -24,4 +24,4 @@ jobs:
 
       - name: Run unit tests
         run: |
-          python -m unittest discover -v --durations
+          python -m unittest discover -v

--- a/README.md
+++ b/README.md
@@ -3,52 +3,102 @@ Do you like to organize your commit messages?
 Follow this simple system while creating your commit messages, and then when it comes time to squash your commits, run Commit-Text-Organizer to clean and categorize all of those messages.
 
 ## Requirements
-Python 3.10 or 3.11 is required to run __Commit-Text-Organizer__.
+Python 3.10 or higher is required to run __Commit-Text-Organizer__.
 This is because the Union Type Operator is used (not available in 3.9 or earlier).
 
 ## Commit Message Structure
-Structure your commits using your own set of headers.
+You commit messages are organized into high level groups, which are defined by their header name.
 
+Structure your commits using your own set of headers, such as:
+- Database Migration 32
+- Database Integration
+- Test Database Migrations
+
+When writing commits, ensure that you add a colon (:) immediately after the header name.
+
+Then, the lines immediately below the header are included in that group. These are called Commit Lines.
+
+### Subjects (Files or Groups of Files)
+A Subject is the start of a Commit Line in a header Group. It will usually describe a change in a single file, but you can group files into the subject.
+
+#### Subject Matching
+Lines in the same Header Group can be merged, but only if the subjects match.
+
+When Content details are merged, they are separated from the Subject, sorted alphabetically, and joined with a comma-space separator.
+
+#### Subject Content Separators
+The subject is separated from content details by one of these separators: (+) or (-).
+
+If a separator appears more than once in a Commit Line, it is ignored.
+
+### Line Prefix Shortcuts
+To reduce typing the same word for so many file changes (such as "Update", or "Create"), CTO includes a Line Prefix recognition and replacement feature.
+
+     cto/text/generation/commit_line_prefixes.py  
+
+It recognizes prefixes (that you can change) and replaces them with the most commonly used words.
+
+#### Existing Prefixes
+| Shortcut | Prefix |
+|----------|--------|
+| c | Create |
+| f | Fix |
+| m | Move |
+| r | Remove |
+| t | Test |
+| u | Update |
+
+#### Existing Secondary Prefixes
+There are also secondary prefixes that can be based on more than one character, and map to other prefixes.
+
+| Shortcut | Prefix |
+|----------|--------|
+| cr | Create |
+| del | Remove |
+| mv | Move |
+| up | Update |
+
+#### Important Commit Line Characters
 - A header ends with a colon ":"
-- Lines under the header are part of that header Group
 - A blank line will start a new group
-
-### Subjects
-A Subject is the start of a Line in a header Group.
-
-- The subject is separated from details by one of these separators (+ or -)
-- Lines with the same Header and Subject are automatically merged
-- Details after the subject are comma-separated
+- Commit Lines start with the star (*)
+- Subject is separated from content by (+) or (-)
+- Content may contain multiple changes that are comma-separated
 
 ### Example
 __Input:__
 ```
 Header 1:
-* Modify File.c - new method hello_world()
-* Modify File.c - new method foo()
+*u File.c - new method hello_world()
+*u File.c - new method foo()
 
 Header 2:
-* Create NewFile.c
+*c NewFile.c
 
 Header 2:
-* Modify NewFile.c - add method bar()
+*r OldFile.c
 ```
 __Output:__
 ```
 Header 1:
-* Modify File.c - new method hello_world(), new method foo()
+* Update File.c - new method hello_world(), new method foo()
 
 Header 2:
 * Create NewFile.c
-* Modify NewFile.c - add method bar()
+* Remove OldFile.c
 ```
 
 ### Sorting
 The sort method of CommitOrganizer will combine groups with matching headers.
 The sort lines in groups method of CommitTextGroup will sort the group's messages alphabetically. 
 
-### Python Script
-The Python script reads and runs Commit-Text-Organizer on a file of your choosing.
+### Launch (Python) Script
+The Launch script prompts user for a path, reads a file and runs Commit-Text-Organizer on it's contents. 
 
-The script will prompt user for the path of the file to read.
-The output will be written to a similar path with a "-organized" suffix. (sorry windows users, this currently messes up the file extension)
+The output will be written to a similar file path with a "-org" suffix attached.
+
+#### Windows Compatibility
+The file extension must be (.txt).
+
+## Project Vision
+The vision for this project is to advance to a multi-functional command line tool and interface that does more commit message text management, so developers like you and me can do less.

--- a/tests/generation/test_commit_line_prefixes.py
+++ b/tests/generation/test_commit_line_prefixes.py
@@ -4,55 +4,60 @@ from text.generation.commit_line_prefixes import update_line
 
 
 class TestCommitLinePrefixes(unittest.TestCase):
-    """Test that commit messages have the correct line prefixes."""
+    """Test that commit messages have the correct line prefixes.
+    """
 
     def test_update_line_no_space(self):
         expected = "* Update README.md - reformat file"
         line = "*u README.md - reformat file"
-        self.assertEquals(
+        self.assertEqual(
             expected, update_line(line),
         )
         line = "*U README.md - reformat file"
-        self.assertEquals(
+        self.assertEqual(
             expected, update_line(line)
         )
 
     def test_update_line_with_space(self):
         expected = "* Update README.md - reformat file"
         line = "* U README.md - reformat file"
-        self.assertEquals(
+        self.assertEqual(
             expected, update_line(line)
         )
 
     def test_update_line_extra_prefix_no_space(self):
         expected = "* Update README.md - reformat file"
         line = "*Up README.md - reformat file"
-        self.assertEquals(
+        self.assertEqual(
             expected, update_line(line)
         )
         line = "*up README.md - reformat file"
-        self.assertEquals(
+        self.assertEqual(
             expected, update_line(line)
         )
 
     def test_update_line_extra_prefix_with_space(self):
         expected = "* Update README.md - reformat file"
         line = "* Up README.md - reformat file"
-        self.assertEquals(
+        self.assertEqual(
             expected, update_line(line)
         )
         line = "* up README.md - reformat file"
-        self.assertEquals(
+        self.assertEqual(
             expected, update_line(line)
         )
 
     def test_update_line_invalid_prefix(self):
         line = "* X README.md - reformat file"
-        self.assertIsNone(update_line(line))
+        self.assertIsNone(
+            update_line(line)
+        )
 
     def test_update_line_already_valid_prefix(self):
         line = "* Update README.md - reformat file"
-        self.assertIsNone(update_line(line))
+        self.assertIsNone(
+            update_line(line)
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_commit_line.py
+++ b/tests/test_commit_line.py
@@ -3,6 +3,9 @@ from text.commit_line import CommitLine
 
 
 class TestCommitLine(unittest.TestCase):
+    """ Testing the Commit Line Class.
+    The Test setup includes a basic Commit Line input, consisting of a subject and content combined into a simple input.
+    """
 
     def setUp(self) -> None:
         self.subjectA = "A Subject"
@@ -13,92 +16,94 @@ class TestCommitLine(unittest.TestCase):
         self.input = "Subject - Content"
         self.commit_line = CommitLine(self.input)
 
-    def test_get_line(self):
-        self.assertEquals(
+    def test_get_line_input_returns_input(self):
+        self.assertEqual(
             self.input,
             self.commit_line.get_input_line()
         )
 
-    def test_get_subject(self):
-        self.assertEquals(
+    def test_get_subject_returns_subject(self):
+        self.assertEqual(
             self.subject,
             self.commit_line.get_subject()
         )
 
-    def test_get_subject_A_minus(self):
-        self.assertEquals(
+    def test_get_subject_A_minus_returns_subject(self):
+        self.assertEqual(
             self.subjectA,
             CommitLine(
                 self.subjectA + ' - ' + self.contentA
             ).get_subject()
         )
-        # Also with no space around separator
-        self.assertEquals(
+        
+    def test_get_subject_A_minus_no_space_returns_subject(self):
+        self.assertEqual(
             self.subjectA,
             CommitLine(
                 self.subjectA + '-' + self.contentA
             ).get_subject()
         )
 
-    def test_get_subject_A_plus(self):
-        self.assertEquals(
+    def test_get_subject_A_plus_returns_subject(self):
+        self.assertEqual(
             self.subjectA,
             CommitLine(
                 self.subjectA + ' + ' + self.contentA
             ).get_subject()
         )
-        # Also with no space around separator
-        self.assertEquals(
+    
+    def test_get_subject_A_plus_returns_subject(self):
+        self.assertEqual(
             self.subjectA,
             CommitLine(
                 self.subjectA + '+' + self.contentA
             ).get_subject()
         )
 
-    def test_get_subject_A_no_separator(self):
-        self.assertEquals(
+    def test_get_subject_A_no_separator_returns_none(self):
+        self.assertEqual(
             None, CommitLine(
                 self.subjectA + ' ' + self.contentA
             ).get_subject()
         )
 
-    def test_get_subject_empty(self):
-        self.assertEquals(
+    def test_get_subject_empty_line_returns_none(self):
+        self.assertEqual(
             None, CommitLine("").get_subject()
         )
 
-    def test_get_content(self):
-        self.assertEquals(
+    def test_get_content_commit_line_returns_content(self):
+        self.assertEqual(
             self.content,
             self.commit_line.get_content()
         )
 
-    def test_get_content_A_minus(self):
-        self.assertEquals(
+    def test_get_content_line_A_minus_returns_content(self):
+        self.assertEqual(
             self.contentA,
             CommitLine(
                 self.subjectA + ' - ' + self.contentA
             ).get_content()
         )
 
-    def test_get_content_A_plus(self):
-        self.assertEquals(
+    def test_get_content_line_A_plus_returns_content(self):
+        self.assertEqual(
             self.contentA,
             CommitLine(
                 self.subjectA + ' + ' + self.contentA
             ).get_content()
         )
 
-    def test_get_content_no_separator(self):
+    def test_get_content_no_separator_returns_line(self):
         line = self.subjectA + ' ' + self.contentA
-        self.assertEquals(
+        self.assertEqual(
             line,
             CommitLine(
                 self.subjectA + ' ' + self.contentA
             ).get_content()
         )
 
-    def test_get_content_empty(self):
+    def test_get_content_empty_line_returns_none(self):
         self.assertIsNone(
             CommitLine("").get_content()
         )


### PR DESCRIPTION
Update the README file.

Add new Python Version 3.12 to the Test Matrix.

Replace deprecated unittest method `assertEquals` with `assertEqual`.