### PR TITLE
Release 0.9.1

### DIFF
--- a/commit_organizer.py
+++ b/commit_organizer.py
@@ -11,21 +11,6 @@ class CommitTextOrganizer:
 		# The PR group will be added to the Groups, so it can be sorted
 		self.pr_group = None
 
-	def read_file(
-			self,
-			file_path: str
-	) -> bool:
-		""" Read and Receive data from a File.
-			Returns True if the file was loaded successfully
-		"""
-		from files.file_management import read_file
-		data = read_file(file_path)
-		if data is not None:
-			self.receive_data(data)
-			return True
-		else:
-			return False
-
 	def receive_data(
 			self,
 			data: str
@@ -77,20 +62,6 @@ class CommitTextOrganizer:
 			self.groups.append(self.pr_group)
 		# Prepend a * to the line
 		self.pr_group.add_line('* ' + line)
-
-	def write_to_file(
-			self,
-			file_name: str
-	) -> bool:
-		""" Write all Groups to a File.
-		"""
-		data = self.output_all_groups()
-		if data is None:
-			return False
-		from files.file_management import write_file
-		return write_file(
-			file_name, data
-		)
 
 	def clear(self):
 		""" Removes all temporary data.

--- a/launch.py
+++ b/launch.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
+from sys import exit
 
 from commit_organizer import CommitTextOrganizer
-from files.file_management import create_new_file_name
+from files.file_management import read_file, write_file, create_new_file_name
 
 
 def run_commit_text_organizer(
@@ -13,11 +14,15 @@ def run_commit_text_organizer(
     # Create an instance of the CTO data structure
     org = CommitTextOrganizer()
     # Load the Input File
-    org.read_file(input_file)
+    if (input_data := read_file(input_file)) is None:
+        exit('Failed to Read Input File')
+    org.receive_data(input_data)
     # Default Processing Operations
     org.autoprocess()
-    # Write the Result to a File
-    org.write_to_file(output_file)
+    # Return all Groups of Text
+    output_data = org.output_all_groups()
+    # Write the Result to the File
+    write_file(input_data.output_file_name, output_data)
 
 
 # Request keyboard input

--- a/launch.py
+++ b/launch.py
@@ -22,7 +22,7 @@ def run_commit_text_organizer(
     # Return all Groups of Text
     output_data = org.output_all_groups()
     # Write the Result to the File
-    write_file(input_data.output_file_name, output_data)
+    write_file(output_file, output_data)
 
 
 # Request keyboard input


### PR DESCRIPTION
This release provides a quick optimization to the __Commit Text Organizer__ class!

The __CTO__ class (in `commit_organizer.py`) contains 2 methods that exist to make the Launch script simpler. This is not necessary.

## commit_organizer.py
- remove method read_file
- remove method write_to_file 

## launch.py 
- replace CTO method read_file  with receive_data method
- replace CTO method write_to_file method with output_all_groups
- import file_management to handle file reading and writing