### PR TITLE
Release 1.1.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/
 
       - name: Sign Distributions
-        uses: dk96-os/gh-action-sigstore-python@v2.1.2rc1-dk96-os
+        uses: dk96-os/gh-action-sigstore-python@v3.1-dk96-os
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="commit-text-organizer",
-    version="1.1.1",
+    version="1.1.2",
     description="A Text Processor Targeted at Organizing Commit Messages.",
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Upgrade Dependencies
- Sigstore 3.x

Previous version 1.1.1 failed to deploy during signing with Sigstore 2.1.5

The error was as follows:
```
File "/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/site-packages/sigstore/_internal/fulcio/client.py", line 166, in <module>
    SignedCertificateTimestamp.register(DetachedFulcioSCT)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'cryptography.hazmat.bindings._rust.x509.Sct' has no attribute 'register'
```

Notice the recent [gh_actions_sigstore_python](https://github.com/sigstore/gh-action-sigstore-python) update includes pinning the cryptography package version: `"cryptography >= 42, < 44"`

In this new version of [cryptography](https://github.com/pyca/cryptography/), you can see under **Files Changed** in [compare 43.0.3 to 44.0.0](https://github.com/pyca/cryptography/compare/43.0.3...44.0.0) when you `Ctrl+f` search: `src/cryptography/hazmat/bindings/_rust/x509`

There is a whole new class definition, and it doesn't include `register`.

My [gh_actions_sigstore_python](https://github.com/DK96-OS/gh-action-sigstore-python) action has been synchronized with the parent repository, and I've tagged it: 3.1-dk96-os